### PR TITLE
Update Zeplin.download.recipe

### DIFF
--- a/Zeplin/Zeplin.download.recipe
+++ b/Zeplin/Zeplin.download.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Zeplin</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://rink.hockeyapp.net/api/2/apps/8926efffe734b6d303d09f41d90c34fc</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -22,17 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%.zip</string>
+				<key>url</key>
+				<string>https://zpl.io/download-mac</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Fix broken sparkle feed by adding direct download link to URLDownloader.