### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Code Line/Art View.pkg.recipe
+++ b/Code Line/Art View.pkg.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>Art View 2</string>
-		<key>BUNDLE_ID</key>
-		<string>com.codelinesoftware.artview-mac</string>
 		<key>NAME</key>
 		<string>Art View</string>
 	</dict>

--- a/HAVAS WORLDWIDE LONDON LIMITED/HKXAppDrawer.pkg.recipe
+++ b/HAVAS WORLDWIDE LONDON LIMITED/HKXAppDrawer.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.HKXAppDrawer</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.globalservs.HKXBITeam</string>
 		<key>NAME</key>
 		<string>HKXAppDrawer</string>
 	</dict>

--- a/HAVAS WORLDWIDE LONDON LIMITED/ScreamingFrogSEOSpider.pkg.recipe
+++ b/HAVAS WORLDWIDE LONDON LIMITED/ScreamingFrogSEOSpider.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>uk.co.screamingfrog.seo.spider</string>
 		<key>NAME</key>
 		<string>Screaming Frog SEO Spider</string>
 	</dict>

--- a/HAVAS WORLDWIDE LONDON LIMITED/yEd.pkg.recipe
+++ b/HAVAS WORLDWIDE LONDON LIMITED/yEd.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.yEd</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.yworks.yEd</string>
 		<key>NAME</key>
 		<string>yEd</string>
 	</dict>

--- a/IP in menu bar/IP in menu bar.pkg.recipe
+++ b/IP in menu bar/IP in menu bar.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.IPinmenubar</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>de.monkeybreadsoftware.freeware.ipinmenubar</string>
 		<key>NAME</key>
 		<string>IP in menu bar</string>
 	</dict>

--- a/Kitabu Ou/Kitabu.pkg.recipe
+++ b/Kitabu Ou/Kitabu.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.Kitabu</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>ee.64.Kitabu</string>
 		<key>NAME</key>
 		<string>Kitabu</string>
 	</dict>

--- a/Oleg Andreev/Gitbox.pkg.recipe
+++ b/Oleg Andreev/Gitbox.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.Gitbox</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.oleganza.gitbox</string>
 		<key>NAME</key>
 		<string>Gitbox</string>
 	</dict>

--- a/Scott Crick/Print Window.pkg.recipe
+++ b/Scott Crick/Print Window.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.PrintWindow</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.searchwaresolutions.PrintWindow</string>
 		<key>NAME</key>
 		<string>Print Window</string>
 	</dict>

--- a/Zeplin/Zeplin.pkg.recipe
+++ b/Zeplin/Zeplin.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.hobbithardcase.pkg.Zeplin</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>io.zeplin.osx</string>
 		<key>NAME</key>
 		<string>Zeplin</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Code Line/Art View.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/Code\ Line/Art\ View.pkg.recipe
Processing repos/HobbitHardcase-recipes/Code Line/Art View.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Art View.zip',
           'url': 'https://www.code-line.com/download/ArtView2.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/downloads/Art View.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/downloads/Art '
                        'View.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/downloads/Art '
                           'View.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art '
                               'View',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Art View.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/downloads/Art View.zip to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art '
                         'View/Art View 2.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.codelinesoftware.artview-mac" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = N2788JM458)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View/Art View 2.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View/Art View 2.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View/Art View 2.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art '
                               'View/Art View 2.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 2.1 in file ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View/Art View 2.app/Contents/Info.plist
{'Output': {'version': '2.1'}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art '
                       'View/Art View 2.app',
           'version': '2.1'}}
AppPkgCreator: BundleID: com.codelinesoftware.artview-mac
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View/Art View 2.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/payload/Applications/Art View 2.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.codelinesoftware.artview-mac',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art '
                                                                    'View '
                                                                    '2-2.1.pkg',
                                                        'version': '2.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/receipts/Art View.pkg-receipt-20210213-225821.plist

The following packages were built:
    Identifier                        Version  Pkg Path                                                                                       
    ----------                        -------  --------                                                                                       
    com.codelinesoftware.artview-mac  2.1      ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ArtView/Art View 2-2.1.pkg  
```

## ❌ HAVAS WORLDWIDE LONDON LIMITED/HKXAppDrawer.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/HAVAS\ WORLDWIDE\ LONDON\ LIMITED/HKXAppDrawer.pkg.recipe
Processing repos/HobbitHardcase-recipes/HAVAS WORLDWIDE LONDON LIMITED/HKXAppDrawer.pkg.recipe...
URLDownloader
{'Input': {'filename': 'HKXAppDrawer.zip', 'url': ''}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.HKXAppDrawer/receipts/HKXAppDrawer.pkg-receipt-20210213-225822.plist

The following recipes failed:
    repos/HobbitHardcase-recipes/HAVAS WORLDWIDE LONDON LIMITED/HKXAppDrawer.pkg.recipe
        Error in com.github.hobbithardcase.pkg.HKXAppDrawer: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', '', '--fail', '--output', '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.HKXAppDrawer/downloads/tmplj6x5t1a']' returned non-zero exit status 3.

Nothing downloaded, packaged or imported.
```

## ✅ HAVAS WORLDWIDE LONDON LIMITED/ScreamingFrogSEOSpider.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/HAVAS\ WORLDWIDE\ LONDON\ LIMITED/ScreamingFrogSEOSpider.pkg.recipe
Processing repos/HobbitHardcase-recipes/HAVAS WORLDWIDE LONDON LIMITED/ScreamingFrogSEOSpider.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(?P<url>https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-(?P<version>.*?).dmg)',
           'url': 'https://www.screamingfrog.co.uk/wp-content/themes/screamingfrog/inc/download-modal.php'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.1.dmg
URLTextSearcher: Found matching text (version): 14.1
URLTextSearcher: Found matching text (match): https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.1.dmg
{'Output': {'match': 'https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.1.dmg',
            'url': 'https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.1.dmg',
            'version': '14.1'}}
URLDownloader
{'Input': {'filename': 'Screaming Frog SEO Spider.dmg',
           'url': 'https://download.screamingfrog.co.uk/products/seo-spider/ScreamingFrogSEOSpider-14.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/downloads/Screaming Frog SEO Spider.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/downloads/Screaming '
                        'Frog SEO Spider.dmg'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/downloads/Screaming '
                         'Frog SEO Spider.dmg/Screaming Frog SEO Spider.app',
           'requirement': 'identifier "uk.co.screamingfrog.seo.spider" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CAHEVC3HZC'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/downloads/Screaming Frog SEO Spider.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.RJW9EW/Screaming Frog SEO Spider.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.RJW9EW/Screaming Frog SEO Spider.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.RJW9EW/Screaming Frog SEO Spider.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {'version': '14.1'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/downloads/Screaming Frog SEO Spider.dmg
AppPkgCreator: Using path '/private/tmp/dmg.pM5Bbt/Screaming Frog SEO Spider.app' matched from globbed '/private/tmp/dmg.pM5Bbt/*.app'.
AppPkgCreator: BundleID: uk.co.screamingfrog.seo.spider
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/Screaming Frog SEO Spider-14.1.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '14.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.ScreamingFrogSEOSpider/receipts/ScreamingFrogSEOSpider.pkg-receipt-20210213-225832.plist

Nothing downloaded, packaged or imported.
```

## ✅ HAVAS WORLDWIDE LONDON LIMITED/yEd.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/HAVAS\ WORLDWIDE\ LONDON\ LIMITED/yEd.pkg.recipe
Processing repos/HobbitHardcase-recipes/HAVAS WORLDWIDE LONDON LIMITED/yEd.pkg.recipe...
YWorksURLProvider
{'Input': {'product_name': 'yEd'}}
http://www.yworks.com/products/yed/demo/yEd-CurrentVersion.txt
YWorksURLProvider: Found URL as http://www.yworks.com/products/yed/demo/yEd-3.20.1_with-JRE14.dmg
{'Output': {'url': 'http://www.yworks.com/products/yed/demo/yEd-3.20.1_with-JRE14.dmg'}}
URLDownloader
{'Input': {'filename': 'yEd.dmg',
           'url': 'http://www.yworks.com/products/yed/demo/yEd-3.20.1_with-JRE14.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/downloads/yEd.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/downloads/yEd.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/downloads/yEd.dmg/yEd.app',
           'requirement': 'identifier "com.yworks.yEd" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'JD89S887M2'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/downloads/yEd.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Iw4JMp/yEd.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Iw4JMp/yEd.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Iw4JMp/yEd.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/downloads/yEd.dmg
AppPkgCreator: Using path '/private/tmp/dmg.dYkVDp/yEd.app' matched from globbed '/private/tmp/dmg.dYkVDp/*.app'.
AppPkgCreator: Version: 3.20.1
AppPkgCreator: BundleID: com.yworks.yEd
AppPkgCreator: Copied /private/tmp/dmg.dYkVDp/yEd.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/payload/Applications/yEd.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.yworks.yEd',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/yEd-3.20.1.pkg',
                                                        'version': '3.20.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.20.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/receipts/yEd.pkg-receipt-20210213-225911.plist

The following packages were built:
    Identifier      Version  Pkg Path                                                                               
    ----------      -------  --------                                                                               
    com.yworks.yEd  3.20.1   ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.yEd/yEd-3.20.1.pkg  
```

## ✅ IP in menu bar/IP in menu bar.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/IP\ in\ menu\ bar/IP\ in\ menu\ bar.pkg.recipe
Processing repos/HobbitHardcase-recipes/IP in menu bar/IP in menu bar.pkg.recipe...
URLDownloader
{'Input': {'filename': 'IP in menu bar.dmg',
           'url': 'https://www.monkeybreadsoftware.de/Software/IPinmenubar.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP in menu bar.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP '
                        'in menu bar.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP '
                         'in menu bar.dmg/IP in menu bar.app',
           'requirement': 'identifier '
                          '"de.monkeybreadsoftware.freeware.ipinmenubar" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'RZ52899P4B'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP in menu bar.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.41CLb4/IP in menu bar.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.41CLb4/IP in menu bar.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.41CLb4/IP in menu bar.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP '
                               'in menu bar.dmg/IP in menu '
                               'bar.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP in menu bar.dmg
Versioner: Found version 4.6.1 in file /private/tmp/dmg.FcTCNd/IP in menu bar.app/Contents/Info.plist
{'Output': {'version': '4.6.1'}}
AppPkgCreator
{'Input': {'version': '4.6.1'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/downloads/IP in menu bar.dmg
AppPkgCreator: Using path '/private/tmp/dmg.S7hFaq/IP in menu bar.app' matched from globbed '/private/tmp/dmg.S7hFaq/*.app'.
AppPkgCreator: BundleID: de.monkeybreadsoftware.freeware.ipinmenubar
AppPkgCreator: Copied /private/tmp/dmg.S7hFaq/IP in menu bar.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/payload/Applications/IP in menu bar.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'de.monkeybreadsoftware.freeware.ipinmenubar',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/IP '
                                                                    'in menu '
                                                                    'bar-4.6.1.pkg',
                                                        'version': '4.6.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.6.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/receipts/IP in menu bar.pkg-receipt-20210213-225922.plist

The following packages were built:
    Identifier                                   Version  Pkg Path                                                                                                 
    ----------                                   -------  --------                                                                                                 
    de.monkeybreadsoftware.freeware.ipinmenubar  4.6.1    ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.IPinmenubar/IP in menu bar-4.6.1.pkg  
```

## ❌ Kitabu Ou/Kitabu.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/Kitabu\ Ou/Kitabu.pkg.recipe
Processing repos/HobbitHardcase-recipes/Kitabu Ou/Kitabu.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Kitabu.zip',
           'url': 'https://www.kitabu.me/files/Kitabu.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Kitabu/receipts/Kitabu.pkg-receipt-20210213-225924.plist

The following recipes failed:
    repos/HobbitHardcase-recipes/Kitabu Ou/Kitabu.pkg.recipe
        Error in com.github.hobbithardcase.pkg.Kitabu: Processor: URLDownloader: Error: Command '['/usr/bin/curl', '--silent', '--show-error', '--no-buffer', '--dump-header', '-', '--speed-time', '30', '--location', '--url', 'https://www.kitabu.me/files/Kitabu.zip', '--fail', '--output', '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Kitabu/downloads/tmpmppjuj5_']' returned non-zero exit status 35.

Nothing downloaded, packaged or imported.
```

## ✅ Oleg Andreev/Gitbox.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/Oleg\ Andreev/Gitbox.pkg.recipe
Processing repos/HobbitHardcase-recipes/Oleg Andreev/Gitbox.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'http://gitboxapp.com/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 1.6.2
SparkleUpdateInfoProvider: Found URL http://d1oa71y4zxyi0a.cloudfront.net/gitbox-1.6.2.zip
{'Output': {'url': 'http://d1oa71y4zxyi0a.cloudfront.net/gitbox-1.6.2.zip',
            'version': '1.6.2'}}
URLDownloader
{'Input': {'filename': 'Gitbox-1.6.2.zip',
           'url': 'http://d1oa71y4zxyi0a.cloudfront.net/gitbox-1.6.2.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/downloads/Gitbox-1.6.2.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/downloads/Gitbox-1.6.2.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/downloads/Gitbox-1.6.2.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Gitbox-1.6.2.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/downloads/Gitbox-1.6.2.zip to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox/Gitbox.app',
           'version': '1.6.2'}}
AppPkgCreator: BundleID: com.oleganza.gitbox
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox/Gitbox.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/payload/Applications/Gitbox.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.oleganza.gitbox',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox-1.6.2.pkg',
                                                        'version': '1.6.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.6.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/receipts/Gitbox.pkg-receipt-20210213-225930.plist

The following packages were built:
    Identifier           Version  Pkg Path                                                                                    
    ----------           -------  --------                                                                                    
    com.oleganza.gitbox  1.6.2    ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Gitbox/Gitbox-1.6.2.pkg  
```

## ✅ Scott Crick/Print Window.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/Scott\ Crick/Print\ Window.pkg.recipe
Processing repos/HobbitHardcase-recipes/Scott Crick/Print Window.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Print Window.dmg',
           'url': 'http://printwindowapp.com/software/printwindow.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print Window.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print '
                        'Window.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print '
                         'Window.dmg/Print Window.app',
           'requirement': 'identifier "com.searchwaresolutions.PrintWindow" '
                          'and anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'RK5R2VM359'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print Window.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.VMlmU4/Print Window.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.VMlmU4/Print Window.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.VMlmU4/Print Window.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print '
                               'Window.dmg/Print '
                               'Window.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print Window.dmg
Versioner: Found version 5.4.2 in file /private/tmp/dmg.KlKhsD/Print Window.app/Contents/Info.plist
{'Output': {'version': '5.4.2'}}
AppPkgCreator
{'Input': {'version': '5.4.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/downloads/Print Window.dmg
AppPkgCreator: Using path '/private/tmp/dmg.2MLoQd/Print Window.app' matched from globbed '/private/tmp/dmg.2MLoQd/*.app'.
AppPkgCreator: BundleID: com.searchwaresolutions.PrintWindow
AppPkgCreator: Copied /private/tmp/dmg.2MLoQd/Print Window.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/payload/Applications/Print Window.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.searchwaresolutions.PrintWindow',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/Print '
                                                                    'Window-5.4.2.pkg',
                                                        'version': '5.4.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '5.4.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/receipts/Print Window.pkg-receipt-20210213-225949.plist

The following packages were built:
    Identifier                           Version  Pkg Path                                                                                               
    ----------                           -------  --------                                                                                               
    com.searchwaresolutions.PrintWindow  5.4.2    ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.PrintWindow/Print Window-5.4.2.pkg  
```

## ✅ Zeplin/Zeplin.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/HobbitHardcase-recipes/Zeplin/Zeplin.pkg.recipe
Processing repos/HobbitHardcase-recipes/Zeplin/Zeplin.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Zeplin.zip', 'url': 'https://zpl.io/download-mac'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/downloads/Zeplin.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/downloads/Zeplin.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/downloads/Zeplin.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename Zeplin.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/downloads/Zeplin.zip to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app',
           'requirement': 'anchor apple generic and identifier "io.zeplin.osx" '
                          'and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "8U3Y4X5WDQ")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app'}}
AppPkgCreator: Version: 3.15
AppPkgCreator: BundleID: io.zeplin.osx
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin/Zeplin.app to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/payload/Applications/Zeplin.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'io.zeplin.osx',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin-3.15.pkg',
                                                        'version': '3.15'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.15'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/receipts/Zeplin.pkg-receipt-20210213-230001.plist

The following packages were built:
    Identifier     Version  Pkg Path                                                                                   
    ----------     -------  --------                                                                                   
    io.zeplin.osx  3.15     ~/Library/AutoPkg/Cache/com.github.hobbithardcase.pkg.Zeplin/Zeplin-3.15.pkg  
```

