### PR TITLE
Deprecate Kitabu recipes

### DIFF
--- a/Kitabu Ou/Kitabu.download.recipe
+++ b/Kitabu Ou/Kitabu.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Kitabu is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>


### PR DESCRIPTION
Kitabu is no longer available for download. This PR deprecates the Kitabu recipes.
