### PR TITLE
Deprecate Gitbox recipes

### DIFF
--- a/Oleg Andreev/Gitbox.download.recipe
+++ b/Oleg Andreev/Gitbox.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Gitbox is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
Gitbox is no longer available for download. This PR deprecates the Gitbox recipes.
